### PR TITLE
Update Store properties to be nullable

### DIFF
--- a/src/Resources/Store.php
+++ b/src/Resources/Store.php
@@ -26,16 +26,16 @@ class Store extends Resource
     /**
      * The email of the store.
      *
-     * @var string
+     * @var string|null
      */
-    public string $address;
+    public ?string $address;
 
     /**
      * The city of the store.
      *
-     * @var string
+     * @var string|null
      */
-    public string $city;
+    public ?string $city;
 
     /**
      * The state of the store.
@@ -47,9 +47,9 @@ class Store extends Resource
     /**
      * The postal code of the store.
      *
-     * @var string
+     * @var string|null
      */
-    public string $postalCode;
+    public ?string $postalCode;
 
     /**
      * The country of the store.
@@ -61,16 +61,16 @@ class Store extends Resource
     /**
      * The phone number of the store.
      *
-     * @var string
+     * @var string|null
      */
-    public string $phoneNumber;
+    public ?string $phoneNumber;
 
     /**
      * The description of the store.
      *
-     * @var string
+     * @var string|null
      */
-    public string $description;
+    public ?string $description;
 
     /**
      * The time when this resource was created.


### PR DESCRIPTION
Hi,
I just found this other bug:


Response:

` 



  Array

  (

      [stores] => Array
          (

              [0] => Array
                  (
                      [id] => e161e92a-fa1c-4d90-a49d-d13a8d00cec6
                      [name] => Company
                      [address] => 
                      [city] => 
                      [region] => 
                      [postal_code] => 
                      [country_code] => 
                      [phone_number] => 
                      [description] => 
                      [created_at] => 2025-03-25T22:37:53.000Z
                      [updated_at] => 2025-03-25T22:37:53.000Z
                      [deleted_at] => 
                  )
  
          )
  
  )

`


Regards